### PR TITLE
Revert 67f2e99, 5ce236f from 7.x to feature; codesniff & filename tokens

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -141,6 +141,26 @@ function islandora_repository_admin(array $form, array &$form_state) {
           '#default_value' => variable_get('islandora_ds_replace_exclude_enforced', 'RELS-EXT,RELS-INT'),
         ),
       ),
+      'islandora_ds_download' => array(
+        '#type' => 'fieldset',
+        '#title' => t('Datastream Configuration'),
+        'islandora_ds_download_filename_pattern' => array(
+          '#type' => 'textfield',
+          '#title' => t('Datastream download filename pattern'),
+          '#description' => t('Control the filenames assigned to datastream downloads.  Filename naming pattern should end with the file extension or [dsfilename:extension].'),
+          '#default_value' => variable_get('islandora_ds_download_filename_pattern', '[dsfilename:parentlabel]_[dsfilename:label].[dsfilename:extension]'),
+        ),
+        'token_help' => array(
+          '#title' => t('Replacement patterns'),
+          '#type' => 'fieldset',
+          '#collapsible' => FALSE,
+          '#collapsed' => FALSE,
+          'help' => array(
+            '#theme' => 'token_tree',
+            '#token_types' => array('dsfilename'),
+          ),
+        ),
+      ),
     ),
   );
   return system_settings_form($form);

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -51,18 +51,11 @@ function islandora_view_datastream(AbstractDatastream $datastream, $download = F
     header('Content-length: ' . $datastream->size);
   }
   if ($download) {
-    // Browsers will not append all extensions.
-    $extension = '.' . islandora_get_extension_for_mimetype($datastream->mimetype);
-    // Prevent adding on a duplicate extension.
-    $label = $datastream->label;
-    $extension_length = strlen($extension);
-    $duplicate_extension_position = strlen($label) > $extension_length ?
-      strripos($label, $extension, -$extension_length) :
-      FALSE;
-    $filename = $label;
-    if ($duplicate_extension_position === FALSE) {
-      $filename .= $extension;
-    }
+    $token_pattern = variable_get('islandora_ds_download_filename_pattern', '[dsfilename:parentlabel]_[dsfilename:label].[dsfilename:extension]');
+    $filename = token_replace($token_pattern, array(
+      'pid' => $datastream->parent->id,
+      'dsid' => $datastream->id)
+    );
     header("Content-Disposition: attachment; filename=\"$filename\"");
   }
 

--- a/islandora.module
+++ b/islandora.module
@@ -2166,3 +2166,82 @@ function islandora_islandora_get_breadcrumb_query_predicates(AbstractObject $obj
     'fedora-rels-ext:isMemberOf',
   );
 }
+
+/**
+ * Implements hook_token_info().
+ */
+function islandora_token_info() {
+  $info['types']['dsfilename'] = array(
+    'name' => 'Datastream tokens',
+    'description' => t("Tokens for islandora relating to datastreams objects."),
+  );
+  $info['tokens']['dsfilename']['fileextension'] = array(
+    'name' => t("Extension from Datastream's Mimetype"),
+    'description' => t("File extension derived from mimetype."),
+  );
+  $info['tokens']['dsfilename']['id'] = array(
+    'name' => t("Datastream's ID"),
+    'description' => t('Datastream ID.'),
+  );
+  $info['tokens']['dsfilename']['label'] = array(
+    'name' => t("Datastream's label"),
+    'description' => t("Datastream label."),
+  );
+  $info['tokens']['dsfilename']['parentpid'] = array(
+    'name' => t("Parent Object's PID"),
+    'description' => t("Full PID of parent object in Fedora repository."),
+  );
+  $info['tokens']['dsfilename']['parentlabel'] = array(
+    'name' => t("Parent Object's label"),
+    'description' => t("Parent object label."),
+  );
+  $info['tokens']['dsfilename']['parentshortpid'] = array(
+    'name' => t("Parent Object's Short PID"),
+    'description' => t("Parent object PID without namespace."),
+  );
+  $info['tokens']['dsfilename']['parentnamespace'] = array(
+    'name' => t("Parent Object's Namespace"),
+    'description' => t("Parent object namespace."),
+  );
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function islandora_tokens($type, $tokens, array $data = array(), array $options = array()) {
+  if ($type == 'dsfilename' & !empty($data['pid'])) {
+    $object = islandora_object_load($data['pid']);
+    $datastream = $object[$data['dsid']];
+    $replacements = array();
+    foreach ($tokens as $name => $original) {
+      if ($name == 'fileextension') {
+        $replacements[$original] = islandora_get_extension_for_mimetype($datastream->mimetype);
+      }
+      if ($datastream) {
+        if ($name == 'id') {
+          $replacements[$original] = $datastream->id;
+        }
+        if ($name == 'label') {
+          $replacements[$original] = $datastream->label;
+        }
+        if ($name == 'parentpid') {
+          $replacements[$original] = $datastream->parent->id;
+        }
+        if ($name == 'parentshortpid') {
+          $temp = explode(':', $datastream->parent->id, 2);
+          $replacements[$original] = $temp[1];
+        }
+        if ($name == 'parentnamespace') {
+          $temp = explode(':', $datastream->parent->id, 2);
+          $replacements[$original] = $temp[0];
+        }
+        if ($name == 'parentlabel') {
+          $replacements[$original] = $datastream->parent->label;
+        }
+      }
+    }
+    return $replacements;
+  }
+  return array();
+}


### PR DESCRIPTION
**JIRA Ticket**: https://ulstracker.atlassian.net/browse/ISLANDORA-273; https://ulstracker.atlassian.net/browse/ISLANDORA-274

# What does this Pull Request do?
Removes two previous commits as a branch for the 7.x fork. FOR REVIEW ONLY. DO NOT COMMIT.

# What's new?
Allows for a git revert of 7.x, allowing upstream commits to be brought to current for 7.x.

# How should this be tested?
Check out 7.x and tokens_for_filenames_feature branches. Run `git diff 7x..tokens_for_filenames_feature`. The diff should replay both 67f2e99, 5ce236f changes.

# Additional Notes:
This change frees up the 7.x, and includes changes for the module as a separate branch to be included for other non-main branches.